### PR TITLE
feat: Phase 1 scraper + downloader 実装 (closes #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+downloads/
+clips.json
+*.mp4
+posted.db
+.env

--- a/downloader.py
+++ b/downloader.py
@@ -1,0 +1,310 @@
+"""
+downloader.py - Google Drive clip downloader
+
+Downloads clips from Google Drive (unauthenticated public file download)
+and tracks posted/downloaded state in posted.db (SQLite).
+
+Usage:
+    python downloader.py --file-id 1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0 [--dry-run]
+    python downloader.py --clips-json clips.json [--dry-run] [--limit 5]
+"""
+
+import argparse
+import json
+import logging
+import re
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DRIVE_DOWNLOAD_URL = "https://drive.usercontent.google.com/download?id={file_id}&export=download"
+DEFAULT_DOWNLOAD_DIR = Path("downloads")
+DEFAULT_DB_PATH = Path("posted.db")
+CHUNK_SIZE = 8192
+REQUEST_TIMEOUT = 60  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
+
+def init_db(db_path: Path = DEFAULT_DB_PATH) -> sqlite3.Connection:
+    """Initialize SQLite DB and return connection."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS clips (
+            uuid TEXT PRIMARY KEY,
+            title TEXT,
+            drive_file_id TEXT,
+            local_path TEXT,
+            downloaded_at TEXT,
+            posted_at TEXT,
+            status TEXT NOT NULL DEFAULT 'pending'
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_clips_status ON clips(status)
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_clips_drive_file_id ON clips(drive_file_id)
+    """)
+    conn.commit()
+    return conn
+
+
+def upsert_clip(conn: sqlite3.Connection, uuid: str, title: str,
+                drive_file_id: Optional[str]) -> None:
+    """Insert or update a clip record (idempotent)."""
+    conn.execute("""
+        INSERT INTO clips (uuid, title, drive_file_id, status)
+        VALUES (?, ?, ?, 'pending')
+        ON CONFLICT(uuid) DO UPDATE SET
+            title = excluded.title,
+            drive_file_id = excluded.drive_file_id
+    """, (uuid, title, drive_file_id))
+    conn.commit()
+
+
+def mark_downloaded(conn: sqlite3.Connection, uuid: str, local_path: str) -> None:
+    """Mark a clip as downloaded."""
+    conn.execute("""
+        UPDATE clips SET local_path = ?, downloaded_at = datetime('now'), status = 'downloaded'
+        WHERE uuid = ?
+    """, (local_path, uuid))
+    conn.commit()
+
+
+def mark_posted(conn: sqlite3.Connection, uuid: str) -> None:
+    """Mark a clip as posted."""
+    conn.execute("""
+        UPDATE clips SET posted_at = datetime('now'), status = 'posted'
+        WHERE uuid = ?
+    """, (uuid,))
+    conn.commit()
+
+
+def is_downloaded(conn: sqlite3.Connection, uuid: str) -> bool:
+    """Check if a clip is already downloaded."""
+    row = conn.execute(
+        "SELECT status, local_path FROM clips WHERE uuid = ?", (uuid,)
+    ).fetchone()
+    if row is None:
+        return False
+    return row["status"] in ("downloaded", "posted") and bool(row["local_path"])
+
+
+def is_posted(conn: sqlite3.Connection, uuid: str) -> bool:
+    """Check if a clip has already been posted."""
+    row = conn.execute("SELECT status FROM clips WHERE uuid = ?", (uuid,)).fetchone()
+    return row is not None and row["status"] == "posted"
+
+
+# ---------------------------------------------------------------------------
+# Downloader
+# ---------------------------------------------------------------------------
+
+def build_download_url(file_id: str) -> str:
+    """Build Google Drive usercontent download URL."""
+    return DRIVE_DOWNLOAD_URL.format(file_id=file_id)
+
+
+def _safe_filename(title: str, file_id: str) -> str:
+    """Generate a safe filename from title and file_id."""
+    safe = re.sub(r'[\\/:*?"<>|]', "_", title)
+    safe = safe.strip().replace(" ", "_")[:60]
+    short_id = file_id[:8]
+    return f"{safe}_{short_id}.mp4"
+
+
+def download_clip(
+    file_id: str,
+    dest_dir: Path = DEFAULT_DOWNLOAD_DIR,
+    filename: Optional[str] = None,
+    dry_run: bool = False,
+    session: Optional[requests.Session] = None,
+) -> Optional[Path]:
+    """
+    Download a Google Drive file by file_id.
+
+    Args:
+        file_id: Google Drive file ID.
+        dest_dir: Directory to save the file.
+        filename: Override filename (default: {file_id}.mp4).
+        dry_run: If True, only verify the URL is reachable (HEAD request), don't save.
+        session: Optional requests.Session (created if not provided).
+
+    Returns:
+        Path to downloaded file, or None on failure/dry-run.
+    """
+    url = build_download_url(file_id)
+    filename = filename or f"{file_id}.mp4"
+    dest_path = dest_dir / filename
+
+    if session is None:
+        session = requests.Session()
+        session.headers.update({
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Linux x86_64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            )
+        })
+
+    if dry_run:
+        logger.info(f"[dry-run] Would download: {url} -> {dest_path}")
+        try:
+            resp = session.head(url, timeout=REQUEST_TIMEOUT, allow_redirects=True)
+            content_type = resp.headers.get("content-type", "")
+            logger.info(f"[dry-run] Status: {resp.status_code}, Content-Type: {content_type}")
+            return None
+        except requests.RequestException as e:
+            logger.error(f"[dry-run] Failed to reach {url}: {e}")
+            return None
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info(f"Downloading {file_id} -> {dest_path}")
+    try:
+        resp = session.get(url, stream=True, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+
+        content_type = resp.headers.get("content-type", "")
+        if "video" not in content_type and "octet-stream" not in content_type:
+            logger.warning(f"Unexpected content-type: {content_type} for {file_id}")
+
+        with open(dest_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
+                if chunk:
+                    f.write(chunk)
+
+        logger.info(f"Downloaded: {dest_path} ({dest_path.stat().st_size} bytes)")
+        return dest_path
+
+    except requests.RequestException as e:
+        logger.error(f"Failed to download {file_id}: {e}")
+        if dest_path.exists():
+            dest_path.unlink()
+        return None
+
+
+def process_clips_json(
+    clips_json: Path,
+    dest_dir: Path = DEFAULT_DOWNLOAD_DIR,
+    db_path: Path = DEFAULT_DB_PATH,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+    skip_downloaded: bool = True,
+) -> dict:
+    """
+    Process a clips.json file, registering clips to DB and downloading each.
+
+    Returns summary dict with counts.
+    """
+    with open(clips_json, encoding="utf-8") as f:
+        clips = json.load(f)
+
+    if limit:
+        clips = clips[:limit]
+
+    conn = init_db(db_path)
+    session = requests.Session()
+
+    summary = {"total": len(clips), "downloaded": 0, "skipped": 0, "failed": 0}
+
+    for clip in clips:
+        uuid = clip.get("uuid") or clip.get("id")
+        title = clip.get("title", "")
+        drive_file_id = clip.get("drive_file_id")
+
+        if not uuid or not drive_file_id:
+            logger.warning(f"Skipping clip with missing uuid/file_id: {clip}")
+            summary["skipped"] += 1
+            continue
+
+        upsert_clip(conn, uuid, title, drive_file_id)
+
+        if skip_downloaded and not dry_run and is_downloaded(conn, uuid):
+            logger.info(f"Already downloaded: {uuid}")
+            summary["skipped"] += 1
+            continue
+
+        filename = _safe_filename(title, drive_file_id)
+        path = download_clip(
+            file_id=drive_file_id,
+            dest_dir=dest_dir,
+            filename=filename,
+            dry_run=dry_run,
+            session=session,
+        )
+
+        if dry_run:
+            summary["downloaded"] += 1
+        elif path:
+            mark_downloaded(conn, uuid, str(path))
+            summary["downloaded"] += 1
+        else:
+            summary["failed"] += 1
+
+        time.sleep(0.5)
+
+    conn.close()
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Google Drive clip downloader")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--file-id", help="Google Drive file ID to download")
+    group.add_argument("--clips-json", type=Path, help="clips.json from scraper")
+
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_DOWNLOAD_DIR,
+                        help="Directory to save downloads")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH,
+                        help="SQLite DB path for tracking")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Verify URLs only, don't save files")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Max clips to process (when using --clips-json)")
+    parser.add_argument("--filename", default=None,
+                        help="Override filename (only with --file-id)")
+    args = parser.parse_args()
+
+    if args.file_id:
+        path = download_clip(
+            file_id=args.file_id,
+            dest_dir=args.output_dir,
+            filename=args.filename,
+            dry_run=args.dry_run,
+        )
+        if path:
+            print(f"Downloaded: {path}")
+        elif args.dry_run:
+            print("[dry-run] Verification complete")
+        else:
+            print("Download failed", flush=True)
+            raise SystemExit(1)
+
+    else:
+        summary = process_clips_json(
+            clips_json=args.clips_json,
+            dest_dir=args.output_dir,
+            db_path=args.db,
+            dry_run=args.dry_run,
+            limit=args.limit,
+        )
+        print(f"Summary: {summary}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: marks tests as integration tests (network required)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31.0
+beautifulsoup4>=4.12.0
+pytest>=7.0.0

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,213 @@
+"""
+scraper.py - vstudio.team-mir.ai/clips スクレイパー
+/clips ページから全クリップ情報を取得してJSONで出力する
+"""
+
+import json
+import re
+import sys
+import argparse
+import time
+import logging
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://vstudio.team-mir.ai"
+CLIPS_URL = f"{BASE_URL}/clips"
+DRIVE_FILE_RE = re.compile(r"drive\.google\.com/file/d/([^/]+)")
+DRIVE_USERCONTENT_DL = "https://drive.usercontent.google.com/download?id={file_id}&export=download"
+
+DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
+
+
+@dataclass
+class Clip:
+    uuid: str
+    drive_file_id: Optional[str]
+    title: str
+    transcript_text: str
+    duration_sec: Optional[float]
+    video_title: Optional[str]
+    clip_url: str
+    drive_url: Optional[str]
+    download_url: Optional[str]
+
+
+def extract_drive_file_id(url: str) -> Optional[str]:
+    """Google Drive URLからfile IDを抽出"""
+    if not url:
+        return None
+    m = DRIVE_FILE_RE.search(url)
+    return m.group(1) if m else None
+
+
+def parse_duration(text: str) -> Optional[float]:
+    """'1:23' 形式 or '0:04' 形式を秒数に変換"""
+    if not text:
+        return None
+    text = text.strip()
+    parts = text.split(":")
+    try:
+        if len(parts) == 2:
+            return int(parts[0]) * 60 + float(parts[1])
+        elif len(parts) == 3:
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
+    except ValueError:
+        pass
+    return None
+
+
+def parse_clips_from_html(html: str) -> list:
+    """HTMLからクリップ一覧をパース"""
+    soup = BeautifulSoup(html, "html.parser")
+    clips = []
+
+    # 各クリップカード: .border.rounded-lg.p-4 が各クリップ
+    cards = soup.select("div.border.rounded-lg.p-4.space-y-3")
+    logger.info(f"Found {len(cards)} clip cards")
+
+    for card in cards:
+        # タイトル & UUID
+        title_a = card.select_one("a.text-sm.font-semibold")
+        if not title_a:
+            continue
+        title = title_a.get_text(strip=True)
+        clip_href = title_a.get("href", "")
+        # /clips/{UUID}
+        uuid_match = re.search(r"/clips/([a-f0-9-]+)", clip_href)
+        uuid = uuid_match.group(1) if uuid_match else ""
+
+        # Drive URL (DLボタン)
+        dl_a = card.select_one("a[href*='drive.google.com/file/d/']")
+        drive_url = dl_a.get("href", "") if dl_a else None
+        drive_file_id = extract_drive_file_id(drive_url) if drive_url else None
+        download_url = DRIVE_USERCONTENT_DL.format(file_id=drive_file_id) if drive_file_id else None
+
+        # 動画タイトル
+        video_a = card.select_one("a.underline.hover\\:text-foreground")
+        video_title = video_a.get_text(strip=True) if video_a else None
+
+        # 再生時間 (font-semibold text-foreground span)
+        duration_span = card.select_one("span.font-semibold.text-foreground")
+        duration_text = ""
+        if duration_span:
+            for svg in duration_span.find_all("svg"):
+                svg.decompose()
+            duration_text = duration_span.get_text(strip=True)
+        duration_sec = parse_duration(duration_text)
+
+        # transcript (最後のp要素)
+        transcript_p = card.select_one("p.text-xs.text-muted-foreground.leading-relaxed")
+        transcript_text = ""
+        if transcript_p:
+            for svg in transcript_p.find_all("svg"):
+                svg.decompose()
+            transcript_text = transcript_p.get_text(strip=True)
+
+        clips.append(Clip(
+            uuid=uuid,
+            drive_file_id=drive_file_id,
+            title=title,
+            transcript_text=transcript_text,
+            duration_sec=duration_sec,
+            video_title=video_title,
+            clip_url=f"{BASE_URL}{clip_href}",
+            drive_url=drive_url,
+            download_url=download_url,
+        ))
+
+    return clips
+
+
+def scrape_page(page: int = 1, session=None):
+    """
+    指定ページのクリップを取得
+    Returns: (clips, total_pages)
+    """
+    if session is None:
+        session = requests.Session()
+        session.headers.update(DEFAULT_HEADERS)
+
+    params = {"page": page}
+    logger.info(f"Fetching page {page}: {CLIPS_URL}")
+    resp = session.get(CLIPS_URL, params=params, timeout=30)
+    resp.raise_for_status()
+
+    # total_pages をHTMLから抽出
+    soup = BeautifulSoup(resp.text, "html.parser")
+    total_pages = 1
+    page_span = soup.find(string=re.compile(r"\d+\s*/\s*\d+"))
+    if page_span:
+        m = re.search(r"(\d+)\s*/\s*(\d+)", page_span)
+        if m:
+            total_pages = int(m.group(2))
+
+    clips = parse_clips_from_html(resp.text)
+    return clips, total_pages
+
+
+def scrape_all(max_pages=None, dry_run=False, delay=1.0):
+    """
+    全ページをスクレイプ
+    dry_run=True: 1ページのみ取得
+    """
+    session = requests.Session()
+    session.headers.update(DEFAULT_HEADERS)
+
+    all_clips = []
+    clips, total_pages = scrape_page(1, session)
+    all_clips.extend(clips)
+    logger.info(f"Page 1/{total_pages}: {len(clips)} clips")
+
+    if dry_run:
+        logger.info("[DRY-RUN] Stopping after page 1")
+        return all_clips
+
+    if max_pages:
+        total_pages = min(total_pages, max_pages)
+
+    for page in range(2, total_pages + 1):
+        time.sleep(delay)
+        clips, _ = scrape_page(page, session)
+        all_clips.extend(clips)
+        logger.info(f"Page {page}/{total_pages}: {len(clips)} clips (total: {len(all_clips)})")
+
+    return all_clips
+
+
+def main():
+    parser = argparse.ArgumentParser(description="vstudio.team-mir.ai/clips スクレイパー")
+    parser.add_argument("--output", "-o", default="clips.json", help="出力JSONファイル名")
+    parser.add_argument("--max-pages", type=int, default=None, help="取得最大ページ数")
+    parser.add_argument("--dry-run", action="store_true", help="1ページのみ取得（テスト用）")
+    parser.add_argument("--delay", type=float, default=1.0, help="ページ間の待機秒数")
+    args = parser.parse_args()
+
+    clips = scrape_all(
+        max_pages=args.max_pages,
+        dry_run=args.dry_run,
+        delay=args.delay,
+    )
+
+    result = [asdict(c) for c in clips]
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    logger.info(f"Saved {len(clips)} clips to {args.output}")
+    print(json.dumps(result[:3], ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,95 @@
+"""
+tests/test_downloader.py - downloader.py のテスト
+"""
+
+import os
+import json
+import pytest
+import tempfile
+from pathlib import Path
+
+from downloader import (
+    build_download_url,
+    download_video,
+    _extract_confirm_token,
+)
+
+TEST_FILE_ID = "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"  # AYA確認済みパブリックID
+
+
+# ===== ユニットテスト =====
+
+def test_build_download_url():
+    url = build_download_url(TEST_FILE_ID)
+    assert url == f"https://drive.usercontent.google.com/download?id={TEST_FILE_ID}&export=download"
+
+
+def test_extract_confirm_token_standard():
+    html = '<input name="confirm" value="abc123XYZ">'
+    assert _extract_confirm_token(html) == "abc123XYZ"
+
+
+def test_extract_confirm_token_query():
+    html = 'href="?confirm=t_XY-z123&id=foo"'
+    assert _extract_confirm_token(html) == "t_XY-z123"
+
+
+def test_extract_confirm_token_none():
+    assert _extract_confirm_token("<html></html>") is None
+
+
+def test_download_dry_run():
+    """dry_run=Trueでは実際にDLしない"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = download_video(
+            file_id=TEST_FILE_ID,
+            output_dir=tmpdir,
+            dry_run=True,
+        )
+    assert result["status"] == "dry_run"
+    assert result["file_id"] == TEST_FILE_ID
+
+
+def test_download_skip_existing():
+    """既存ファイルがあればスキップ"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # 空ファイルを事前作成
+        dummy = Path(tmpdir) / f"{TEST_FILE_ID}.mp4"
+        dummy.write_bytes(b"dummy")
+
+        result = download_video(
+            file_id=TEST_FILE_ID,
+            output_dir=tmpdir,
+            overwrite=False,
+        )
+    assert result["status"] == "skipped"
+
+
+# ===== 結合テスト（実際のDL）=====
+
+@pytest.mark.integration
+def test_download_real_video():
+    """実際にGoogle DriveからMP4をDL (AYA確認済みパブリックID)"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = download_video(
+            file_id=TEST_FILE_ID,
+            output_dir=tmpdir,
+            overwrite=True,
+        )
+
+    print(f"\nDL結果: {json.dumps(result, ensure_ascii=False, indent=2)}")
+
+    assert result["status"] == "success", f"DL失敗: {result['status']}"
+    assert result["size_bytes"] > 0, "ファイルサイズが0"
+    assert "video" in (result["content_type"] or ""), f"Content-Type不正: {result['content_type']}"
+
+
+@pytest.mark.integration
+def test_download_http_200():
+    """DL URLがHTTP 200を返すことを確認"""
+    import requests
+    url = build_download_url(TEST_FILE_ID)
+    resp = requests.head(url, timeout=15, allow_redirects=True)
+    assert resp.status_code == 200, f"HTTP {resp.status_code}"
+    print(f"\nHTTP Status: {resp.status_code}, Content-Type: {resp.headers.get('Content-Type')}")
+

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,95 +1,341 @@
 """
-tests/test_downloader.py - downloader.py のテスト
+tests/test_downloader.py - downloader.py unit tests
+
+Uses unittest.mock to avoid real HTTP/filesystem calls.
+One live HTTP test is gated behind MIRAI_LIVE_TEST env var.
 """
 
-import os
 import json
-import pytest
+import os
+import sqlite3
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch, mock_open
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from downloader import (
     build_download_url,
-    download_video,
-    _extract_confirm_token,
+    init_db,
+    upsert_clip,
+    mark_downloaded,
+    mark_posted,
+    is_downloaded,
+    is_posted,
+    download_clip,
+    _safe_filename,
+    process_clips_json,
+    DEFAULT_DB_PATH,
+    DEFAULT_DOWNLOAD_DIR,
 )
 
-TEST_FILE_ID = "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"  # AYA確認済みパブリックID
+
+# ---------------------------------------------------------------------------
+# build_download_url
+# ---------------------------------------------------------------------------
+
+class TestBuildDownloadUrl:
+    def test_contains_file_id(self):
+        url = build_download_url("abc123")
+        assert "abc123" in url
+
+    def test_uses_drive_usercontent_domain(self):
+        url = build_download_url("abc123")
+        assert "drive.usercontent.google.com" in url
+
+    def test_has_export_download_param(self):
+        url = build_download_url("abc123")
+        assert "export=download" in url
+
+    def test_known_file_id(self):
+        fid = "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"
+        url = build_download_url(fid)
+        expected = f"https://drive.usercontent.google.com/download?id={fid}&export=download"
+        assert url == expected
 
 
-# ===== ユニットテスト =====
+# ---------------------------------------------------------------------------
+# _safe_filename
+# ---------------------------------------------------------------------------
 
-def test_build_download_url():
-    url = build_download_url(TEST_FILE_ID)
-    assert url == f"https://drive.usercontent.google.com/download?id={TEST_FILE_ID}&export=download"
+class TestSafeFilename:
+    def test_has_mp4_extension(self):
+        assert _safe_filename("test", "abc12345").endswith(".mp4")
+
+    def test_contains_short_file_id(self):
+        name = _safe_filename("title", "abc12345xyz")
+        assert "abc12345" in name
+
+    def test_removes_forbidden_chars(self):
+        name = _safe_filename('test/file:name*?', "abc12345")
+        assert "/" not in name
+        assert ":" not in name
+        assert "*" not in name
+        assert "?" not in name
+
+    def test_max_length(self):
+        long_title = "a" * 200
+        name = _safe_filename(long_title, "abc12345")
+        assert len(name) <= 80  # 60 chars + underscore + 8 chars + .mp4
 
 
-def test_extract_confirm_token_standard():
-    html = '<input name="confirm" value="abc123XYZ">'
-    assert _extract_confirm_token(html) == "abc123XYZ"
+# ---------------------------------------------------------------------------
+# Database operations
+# ---------------------------------------------------------------------------
+
+class TestDatabase:
+    def setup_method(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = Path(self.tmp.name)
+        self.conn = init_db(self.db_path)
+
+    def teardown_method(self):
+        self.conn.close()
+        self.db_path.unlink(missing_ok=True)
+
+    def test_init_creates_clips_table(self):
+        tables = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='clips'"
+        ).fetchall()
+        assert len(tables) == 1
+
+    def test_upsert_inserts_new_clip(self):
+        upsert_clip(self.conn, "uuid-1", "Title 1", "file-id-1")
+        row = self.conn.execute("SELECT * FROM clips WHERE uuid = 'uuid-1'").fetchone()
+        assert row is not None
+        assert row["title"] == "Title 1"
+        assert row["drive_file_id"] == "file-id-1"
+        assert row["status"] == "pending"
+
+    def test_upsert_is_idempotent(self):
+        upsert_clip(self.conn, "uuid-1", "Title 1", "file-id-1")
+        upsert_clip(self.conn, "uuid-1", "Title 1 updated", "file-id-1")
+        rows = self.conn.execute("SELECT * FROM clips WHERE uuid = 'uuid-1'").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["title"] == "Title 1 updated"
+
+    def test_mark_downloaded_updates_status(self):
+        upsert_clip(self.conn, "uuid-1", "Title", "fid")
+        mark_downloaded(self.conn, "uuid-1", "/tmp/test.mp4")
+        row = self.conn.execute("SELECT * FROM clips WHERE uuid = 'uuid-1'").fetchone()
+        assert row["status"] == "downloaded"
+        assert row["local_path"] == "/tmp/test.mp4"
+        assert row["downloaded_at"] is not None
+
+    def test_mark_posted_updates_status(self):
+        upsert_clip(self.conn, "uuid-1", "Title", "fid")
+        mark_downloaded(self.conn, "uuid-1", "/tmp/test.mp4")
+        mark_posted(self.conn, "uuid-1")
+        row = self.conn.execute("SELECT * FROM clips WHERE uuid = 'uuid-1'").fetchone()
+        assert row["status"] == "posted"
+        assert row["posted_at"] is not None
+
+    def test_is_downloaded_false_for_new_clip(self):
+        upsert_clip(self.conn, "uuid-1", "Title", "fid")
+        assert is_downloaded(self.conn, "uuid-1") is False
+
+    def test_is_downloaded_true_after_mark(self):
+        upsert_clip(self.conn, "uuid-1", "Title", "fid")
+        mark_downloaded(self.conn, "uuid-1", "/tmp/test.mp4")
+        assert is_downloaded(self.conn, "uuid-1") is True
+
+    def test_is_downloaded_true_after_posted(self):
+        upsert_clip(self.conn, "uuid-1", "Title", "fid")
+        mark_downloaded(self.conn, "uuid-1", "/tmp/test.mp4")
+        mark_posted(self.conn, "uuid-1")
+        assert is_downloaded(self.conn, "uuid-1") is True
+
+    def test_is_downloaded_false_for_unknown_uuid(self):
+        assert is_downloaded(self.conn, "nonexistent-uuid") is False
+
+    def test_is_posted_false_for_new_clip(self):
+        upsert_clip(self.conn, "uuid-1", "Title", "fid")
+        assert is_posted(self.conn, "uuid-1") is False
+
+    def test_is_posted_true_after_mark(self):
+        upsert_clip(self.conn, "uuid-1", "Title", "fid")
+        mark_posted(self.conn, "uuid-1")
+        assert is_posted(self.conn, "uuid-1") is True
+
+    def test_is_posted_false_for_unknown_uuid(self):
+        assert is_posted(self.conn, "nonexistent-uuid") is False
 
 
-def test_extract_confirm_token_query():
-    html = 'href="?confirm=t_XY-z123&id=foo"'
-    assert _extract_confirm_token(html) == "t_XY-z123"
+# ---------------------------------------------------------------------------
+# download_clip (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+class TestDownloadClip:
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.dest_dir = Path(self.tmp_dir)
+
+    def _make_session(self, status_code=200, content_type="video/mp4", content=b"fake_video"):
+        session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.headers = {"content-type": content_type}
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.iter_content = MagicMock(return_value=[content])
+        session.get = MagicMock(return_value=mock_resp)
+        session.head = MagicMock(return_value=mock_resp)
+        return session
+
+    def test_download_returns_path(self):
+        session = self._make_session()
+        result = download_clip("test_file_id", dest_dir=self.dest_dir, session=session)
+        assert result is not None
+        assert result.exists()
+
+    def test_download_file_has_content(self):
+        session = self._make_session(content=b"video_data_here")
+        result = download_clip("test_file_id", dest_dir=self.dest_dir, session=session)
+        assert result is not None
+        assert result.read_bytes() == b"video_data_here"
+
+    def test_dry_run_returns_none(self):
+        session = self._make_session()
+        result = download_clip("test_file_id", dest_dir=self.dest_dir,
+                               dry_run=True, session=session)
+        assert result is None
+
+    def test_dry_run_does_not_create_file(self):
+        session = self._make_session()
+        download_clip("test_file_id", dest_dir=self.dest_dir,
+                      dry_run=True, session=session)
+        files = list(self.dest_dir.glob("*.mp4"))
+        assert len(files) == 0
+
+    def test_custom_filename(self):
+        session = self._make_session()
+        result = download_clip("fid", dest_dir=self.dest_dir,
+                               filename="custom.mp4", session=session)
+        assert result is not None
+        assert result.name == "custom.mp4"
+
+    def test_http_error_returns_none(self):
+        import requests
+        session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.HTTPError("404")
+        session.get = MagicMock(return_value=mock_resp)
+        result = download_clip("bad_id", dest_dir=self.dest_dir, session=session)
+        assert result is None
+
+    def test_creates_dest_dir_if_missing(self):
+        new_dir = self.dest_dir / "subdir" / "nested"
+        session = self._make_session()
+        result = download_clip("fid", dest_dir=new_dir, session=session)
+        assert new_dir.exists()
+
+    def test_default_filename_has_mp4_extension(self):
+        session = self._make_session()
+        result = download_clip("my_file_id", dest_dir=self.dest_dir, session=session)
+        assert result is not None
+        assert result.suffix == ".mp4"
 
 
-def test_extract_confirm_token_none():
-    assert _extract_confirm_token("<html></html>") is None
+# ---------------------------------------------------------------------------
+# process_clips_json
+# ---------------------------------------------------------------------------
 
+class TestProcessClipsJson:
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.dest_dir = Path(self.tmp_dir) / "downloads"
+        self.db_path = Path(self.tmp_dir) / "test.db"
+        self.clips_json = Path(self.tmp_dir) / "clips.json"
 
-def test_download_dry_run():
-    """dry_run=Trueでは実際にDLしない"""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        result = download_video(
-            file_id=TEST_FILE_ID,
-            output_dir=tmpdir,
-            dry_run=True,
+    def _write_clips(self, clips):
+        with open(self.clips_json, "w") as f:
+            json.dump(clips, f)
+
+    def test_empty_clips_returns_zero_summary(self):
+        self._write_clips([])
+        summary = process_clips_json(
+            self.clips_json, dest_dir=self.dest_dir, db_path=self.db_path, dry_run=True
         )
-    assert result["status"] == "dry_run"
-    assert result["file_id"] == TEST_FILE_ID
+        assert summary["total"] == 0
+        assert summary["downloaded"] == 0
 
-
-def test_download_skip_existing():
-    """既存ファイルがあればスキップ"""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # 空ファイルを事前作成
-        dummy = Path(tmpdir) / f"{TEST_FILE_ID}.mp4"
-        dummy.write_bytes(b"dummy")
-
-        result = download_video(
-            file_id=TEST_FILE_ID,
-            output_dir=tmpdir,
-            overwrite=False,
+    def test_clips_missing_drive_file_id_are_skipped(self):
+        self._write_clips([{"uuid": "u1", "title": "T", "drive_file_id": None}])
+        summary = process_clips_json(
+            self.clips_json, dest_dir=self.dest_dir, db_path=self.db_path, dry_run=True
         )
-    assert result["status"] == "skipped"
+        assert summary["skipped"] == 1
+
+    def test_limit_parameter(self):
+        clips = [
+            {"uuid": f"u{i}", "title": f"T{i}", "drive_file_id": f"fid{i}"}
+            for i in range(10)
+        ]
+        self._write_clips(clips)
+        with patch("downloader.download_clip", return_value=None) as mock_dl:
+            summary = process_clips_json(
+                self.clips_json, dest_dir=self.dest_dir, db_path=self.db_path,
+                dry_run=True, limit=3
+            )
+        assert summary["total"] == 3
+
+    def test_dry_run_does_not_mark_downloaded_in_db(self):
+        clips = [{"uuid": "u1", "title": "T", "drive_file_id": "fid1"}]
+        self._write_clips(clips)
+        with patch("downloader.download_clip", return_value=None):
+            process_clips_json(
+                self.clips_json, dest_dir=self.dest_dir, db_path=self.db_path, dry_run=True
+            )
+        conn = init_db(self.db_path)
+        row = conn.execute("SELECT status FROM clips WHERE uuid = 'u1'").fetchone()
+        conn.close()
+        # dry_run: clip is registered but not marked downloaded
+        assert row is not None
+        assert row["status"] == "pending"
+
+    def test_already_downloaded_clips_are_skipped(self):
+        clips = [{"uuid": "u1", "title": "T", "drive_file_id": "fid1"}]
+        self._write_clips(clips)
+        conn = init_db(self.db_path)
+        upsert_clip(conn, "u1", "T", "fid1")
+        mark_downloaded(conn, "u1", "/tmp/already.mp4")
+        conn.close()
+
+        with patch("downloader.download_clip") as mock_dl:
+            summary = process_clips_json(
+                self.clips_json, dest_dir=self.dest_dir, db_path=self.db_path,
+                dry_run=False, skip_downloaded=True
+            )
+        mock_dl.assert_not_called()
+        assert summary["skipped"] == 1
 
 
-# ===== 結合テスト（実際のDL）=====
+# ---------------------------------------------------------------------------
+# Live HTTP test (gated)
+# ---------------------------------------------------------------------------
 
-@pytest.mark.integration
-def test_download_real_video():
-    """実際にGoogle DriveからMP4をDL (AYA確認済みパブリックID)"""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        result = download_video(
-            file_id=TEST_FILE_ID,
-            output_dir=tmpdir,
-            overwrite=True,
-        )
+@pytest.mark.skipif(
+    not os.environ.get("MIRAI_LIVE_TEST"),
+    reason="Set MIRAI_LIVE_TEST=1 to run live HTTP tests"
+)
+class TestLiveDownload:
+    """
+    Live integration test: verifies the confirmed working Drive file ID.
+    Requires internet access. Run with: MIRAI_LIVE_TEST=1 pytest tests/test_downloader.py::TestLiveDownload
+    """
 
-    print(f"\nDL結果: {json.dumps(result, ensure_ascii=False, indent=2)}")
+    CONFIRMED_FILE_ID = "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"
 
-    assert result["status"] == "success", f"DL失敗: {result['status']}"
-    assert result["size_bytes"] > 0, "ファイルサイズが0"
-    assert "video" in (result["content_type"] or ""), f"Content-Type不正: {result['content_type']}"
+    def test_live_download_http_200(self):
+        import requests
+        url = build_download_url(self.CONFIRMED_FILE_ID)
+        resp = requests.get(url, stream=True, timeout=30)
+        assert resp.status_code == 200
 
-
-@pytest.mark.integration
-def test_download_http_200():
-    """DL URLがHTTP 200を返すことを確認"""
-    import requests
-    url = build_download_url(TEST_FILE_ID)
-    resp = requests.head(url, timeout=15, allow_redirects=True)
-    assert resp.status_code == 200, f"HTTP {resp.status_code}"
-    print(f"\nHTTP Status: {resp.status_code}, Content-Type: {resp.headers.get('Content-Type')}")
-
+    def test_live_download_content_type_video(self):
+        import requests
+        url = build_download_url(self.CONFIRMED_FILE_ID)
+        resp = requests.get(url, stream=True, timeout=30)
+        content_type = resp.headers.get("content-type", "")
+        assert "video" in content_type or "octet-stream" in content_type

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,125 @@
+"""
+tests/test_scraper.py - scraper.py のテスト
+"""
+
+import json
+import pytest
+import requests
+
+from scraper import (
+    extract_drive_file_id,
+    parse_duration,
+    parse_clips_from_html,
+    scrape_page,
+    DRIVE_USERCONTENT_DL,
+)
+
+
+# ===== ユニットテスト =====
+
+def test_extract_drive_file_id_standard():
+    url = "https://drive.google.com/file/d/18z__BBptnKfF62ncKmpCftUzaG81nOJ8/view?usp=drivesdk"
+    assert extract_drive_file_id(url) == "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"
+
+
+def test_extract_drive_file_id_none():
+    assert extract_drive_file_id(None) is None
+    assert extract_drive_file_id("https://example.com") is None
+
+
+def test_parse_duration_mm_ss():
+    assert parse_duration("1:23") == 83.0
+    assert parse_duration("0:04") == 4.0
+    assert parse_duration("4:07") == 247.0
+
+
+def test_parse_duration_invalid():
+    assert parse_duration("") is None
+    assert parse_duration(None) is None
+    assert parse_duration("abc") is None
+
+
+def test_download_url_format():
+    file_id = "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"
+    expected = f"https://drive.usercontent.google.com/download?id={file_id}&export=download"
+    result = DRIVE_USERCONTENT_DL.format(file_id=file_id)
+    assert result == expected
+
+
+# ===== HTMLパーステスト =====
+
+SAMPLE_HTML = """
+<html><body>
+<div class="border rounded-lg p-4 space-y-3 hover:bg-muted/50">
+  <div class="flex items-start justify-between gap-3">
+    <a class="text-sm font-semibold hover:underline" href="/clips/8ba8cd03-bca6-438f-a7f6-67445b0b806e">
+      街頭演説で出会ったバス誘導員からの励ましの言葉
+    </a>
+    <div>
+      <a href="https://drive.google.com/file/d/1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0/view?usp=drivesdk"
+         target="_blank" rel="noopener noreferrer"
+         class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-white bg-black rounded">
+        DL
+      </a>
+    </div>
+  </div>
+  <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+    <span class="inline-flex items-center gap-1">
+      <a class="underline hover:text-foreground" href="/videos/6b18bb52">テスト動画タイトル.mp4</a>
+    </span>
+    <span class="inline-flex items-center gap-1 font-semibold text-foreground">
+      <svg></svg>1:26
+    </span>
+    <span>2026/02/07 23:19</span>
+  </div>
+  <p class="text-xs text-muted-foreground leading-relaxed line-clamp-2">
+    <svg></svg>これはテストのtranscriptです。
+  </p>
+</div>
+</body></html>
+"""
+
+def test_parse_clips_from_html_basic():
+    clips = parse_clips_from_html(SAMPLE_HTML)
+    assert len(clips) == 1
+    clip = clips[0]
+    assert clip.uuid == "8ba8cd03-bca6-438f-a7f6-67445b0b806e"
+    assert clip.drive_file_id == "1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0"
+    assert "バス誘導員" in clip.title
+    assert clip.duration_sec == 86.0
+    assert "transcript" in clip.transcript_text
+
+
+def test_parse_clips_drive_url_present():
+    clips = parse_clips_from_html(SAMPLE_HTML)
+    assert clips[0].download_url is not None
+    assert "drive.usercontent.google.com" in clips[0].download_url
+    assert clips[0].drive_file_id in clips[0].download_url
+
+
+def test_parse_clips_empty_html():
+    clips = parse_clips_from_html("<html><body></body></html>")
+    assert clips == []
+
+
+# ===== 結合テスト（実際のHTTP）=====
+
+@pytest.mark.integration
+def test_scrape_page_live():
+    """実際のサイトから1ページ取得するテスト"""
+    clips, total_pages = scrape_page(1)
+    assert len(clips) > 0, "クリップが取得できなかった"
+    assert total_pages >= 1
+
+    # スキーマ検証
+    for clip in clips:
+        assert clip.uuid, f"UUID空: {clip}"
+        assert clip.title, f"タイトル空: {clip}"
+        # Drive URLが存在する場合はfile_idも必要
+        if clip.drive_url:
+            assert clip.drive_file_id, f"drive_file_idがない: {clip}"
+            assert clip.download_url, f"download_urlがない: {clip}"
+
+    print(f"\n取得クリップ数: {len(clips)}, 総ページ数: {total_pages}")
+    print(f"サンプル: {clips[0].title} / {clips[0].drive_file_id}")
+

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,125 +1,174 @@
 """
-tests/test_scraper.py - scraper.py のテスト
+tests/test_scraper.py - scraper.py unit tests
 """
 
 import json
+import re
 import pytest
-import requests
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from scraper import (
     extract_drive_file_id,
-    parse_duration,
     parse_clips_from_html,
-    scrape_page,
-    DRIVE_USERCONTENT_DL,
+    parse_duration,
+    Clip,
 )
 
 
-# ===== ユニットテスト =====
+# ---------------------------------------------------------------------------
+# extract_drive_file_id
+# ---------------------------------------------------------------------------
 
-def test_extract_drive_file_id_standard():
-    url = "https://drive.google.com/file/d/18z__BBptnKfF62ncKmpCftUzaG81nOJ8/view?usp=drivesdk"
-    assert extract_drive_file_id(url) == "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"
+class TestExtractDriveFileId:
+    def test_standard_drive_url(self):
+        url = "https://drive.google.com/file/d/1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0/view?usp=drivesdk"
+        assert extract_drive_file_id(url) == "1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0"
 
+    def test_confirmed_working_file_id(self):
+        url = "https://drive.google.com/file/d/18z__BBptnKfF62ncKmpCftUzaG81nOJ8/view"
+        assert extract_drive_file_id(url) == "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"
 
-def test_extract_drive_file_id_none():
-    assert extract_drive_file_id(None) is None
-    assert extract_drive_file_id("https://example.com") is None
+    def test_empty_url_returns_none(self):
+        assert extract_drive_file_id("") is None
 
+    def test_none_url_returns_none(self):
+        assert extract_drive_file_id(None) is None
 
-def test_parse_duration_mm_ss():
-    assert parse_duration("1:23") == 83.0
-    assert parse_duration("0:04") == 4.0
-    assert parse_duration("4:07") == 247.0
+    def test_non_drive_url_returns_none(self):
+        assert extract_drive_file_id("https://example.com/file") is None
 
-
-def test_parse_duration_invalid():
-    assert parse_duration("") is None
-    assert parse_duration(None) is None
-    assert parse_duration("abc") is None
-
-
-def test_download_url_format():
-    file_id = "18z__BBptnKfF62ncKmpCftUzaG81nOJ8"
-    expected = f"https://drive.usercontent.google.com/download?id={file_id}&export=download"
-    result = DRIVE_USERCONTENT_DL.format(file_id=file_id)
-    assert result == expected
+    def test_file_id_with_underscores(self):
+        url = "https://drive.google.com/file/d/abc_123-XYZ/view"
+        assert extract_drive_file_id(url) == "abc_123-XYZ"
 
 
-# ===== HTMLパーステスト =====
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
 
-SAMPLE_HTML = """
+class TestParseDuration:
+    def test_mm_ss(self):
+        assert parse_duration("1:23") == pytest.approx(83.0)
+
+    def test_zero_mm_ss(self):
+        assert parse_duration("0:04") == pytest.approx(4.0)
+
+    def test_hh_mm_ss(self):
+        assert parse_duration("1:02:03") == pytest.approx(3723.0)
+
+    def test_empty_string_returns_none(self):
+        assert parse_duration("") is None
+
+    def test_none_returns_none(self):
+        assert parse_duration(None) is None
+
+    def test_invalid_returns_none(self):
+        assert parse_duration("invalid") is None
+
+    def test_whitespace_stripped(self):
+        assert parse_duration("  2:30  ") == pytest.approx(150.0)
+
+
+# ---------------------------------------------------------------------------
+# parse_clips_from_html - structure tests using synthetic HTML
+# ---------------------------------------------------------------------------
+
+SAMPLE_CARD_HTML = """
 <html><body>
-<div class="border rounded-lg p-4 space-y-3 hover:bg-muted/50">
-  <div class="flex items-start justify-between gap-3">
-    <a class="text-sm font-semibold hover:underline" href="/clips/8ba8cd03-bca6-438f-a7f6-67445b0b806e">
-      街頭演説で出会ったバス誘導員からの励ましの言葉
-    </a>
-    <div>
-      <a href="https://drive.google.com/file/d/1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0/view?usp=drivesdk"
-         target="_blank" rel="noopener noreferrer"
-         class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-white bg-black rounded">
-        DL
-      </a>
-    </div>
-  </div>
-  <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-    <span class="inline-flex items-center gap-1">
-      <a class="underline hover:text-foreground" href="/videos/6b18bb52">テスト動画タイトル.mp4</a>
-    </span>
-    <span class="inline-flex items-center gap-1 font-semibold text-foreground">
-      <svg></svg>1:26
-    </span>
-    <span>2026/02/07 23:19</span>
-  </div>
-  <p class="text-xs text-muted-foreground leading-relaxed line-clamp-2">
-    <svg></svg>これはテストのtranscriptです。
+<div class="border rounded-lg p-4 space-y-3">
+  <a href="/clips/550e8400-e29b-41d4-a716-446655440000" class="text-sm font-semibold">
+    テストクリップタイトル
+  </a>
+  <a href="https://drive.google.com/file/d/1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0/view?usp=drivesdk">
+    Download
+  </a>
+  <a href="/videos/v123" class="underline hover:text-foreground">
+    元動画タイトル
+  </a>
+  <span class="font-semibold text-foreground">1:23</span>
+  <p class="text-xs text-muted-foreground leading-relaxed">
+    これはトランスクリプトのサンプルです
   </p>
 </div>
 </body></html>
 """
 
-def test_parse_clips_from_html_basic():
-    clips = parse_clips_from_html(SAMPLE_HTML)
-    assert len(clips) == 1
-    clip = clips[0]
-    assert clip.uuid == "8ba8cd03-bca6-438f-a7f6-67445b0b806e"
-    assert clip.drive_file_id == "1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0"
-    assert "バス誘導員" in clip.title
-    assert clip.duration_sec == 86.0
-    assert "transcript" in clip.transcript_text
 
+class TestParseClipsFromHtml:
+    def test_parses_one_clip(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert len(clips) == 1
 
-def test_parse_clips_drive_url_present():
-    clips = parse_clips_from_html(SAMPLE_HTML)
-    assert clips[0].download_url is not None
-    assert "drive.usercontent.google.com" in clips[0].download_url
-    assert clips[0].drive_file_id in clips[0].download_url
+    def test_clip_has_uuid(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert clips[0].uuid == "550e8400-e29b-41d4-a716-446655440000"
 
+    def test_clip_has_title(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert clips[0].title == "テストクリップタイトル"
 
-def test_parse_clips_empty_html():
-    clips = parse_clips_from_html("<html><body></body></html>")
-    assert clips == []
+    def test_clip_has_drive_file_id(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert clips[0].drive_file_id == "1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0"
 
+    def test_clip_has_download_url(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert clips[0].download_url is not None
+        assert "1VEyqtWH14gE6xjmsDDv8-qXbtBPWQtM0" in clips[0].download_url
 
-# ===== 結合テスト（実際のHTTP）=====
+    def test_clip_has_duration(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert clips[0].duration_sec == pytest.approx(83.0)
 
-@pytest.mark.integration
-def test_scrape_page_live():
-    """実際のサイトから1ページ取得するテスト"""
-    clips, total_pages = scrape_page(1)
-    assert len(clips) > 0, "クリップが取得できなかった"
-    assert total_pages >= 1
+    def test_clip_has_transcript(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert "トランスクリプト" in clips[0].transcript_text
 
-    # スキーマ検証
-    for clip in clips:
-        assert clip.uuid, f"UUID空: {clip}"
-        assert clip.title, f"タイトル空: {clip}"
-        # Drive URLが存在する場合はfile_idも必要
-        if clip.drive_url:
-            assert clip.drive_file_id, f"drive_file_idがない: {clip}"
-            assert clip.download_url, f"download_urlがない: {clip}"
+    def test_clip_has_video_title(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert clips[0].video_title == "元動画タイトル"
 
-    print(f"\n取得クリップ数: {len(clips)}, 総ページ数: {total_pages}")
-    print(f"サンプル: {clips[0].title} / {clips[0].drive_file_id}")
+    def test_clip_has_clip_url(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert "/clips/550e8400" in clips[0].clip_url
 
+    def test_empty_html_returns_empty_list(self):
+        clips = parse_clips_from_html("<html><body></body></html>")
+        assert clips == []
+
+    def test_multiple_clips(self):
+        html = SAMPLE_CARD_HTML + """
+<html><body>
+<div class="border rounded-lg p-4 space-y-3">
+  <a href="/clips/aaaabbbb-0000-1111-2222-333344445555" class="text-sm font-semibold">
+    別のクリップ
+  </a>
+  <a href="https://drive.google.com/file/d/18z__BBptnKfF62ncKmpCftUzaG81nOJ8/view">
+    Download
+  </a>
+</div>
+</body></html>
+"""
+        clips = parse_clips_from_html(html)
+        assert len(clips) == 2
+
+    def test_returns_clip_dataclass(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        assert isinstance(clips[0], Clip)
+
+    def test_clip_schema_has_required_fields(self):
+        clips = parse_clips_from_html(SAMPLE_CARD_HTML)
+        clip = clips[0]
+        # All required fields must be present
+        assert hasattr(clip, "uuid")
+        assert hasattr(clip, "drive_file_id")
+        assert hasattr(clip, "title")
+        assert hasattr(clip, "transcript_text")
+        assert hasattr(clip, "duration_sec")
+        assert hasattr(clip, "video_title")
+        assert hasattr(clip, "clip_url")
+        assert hasattr(clip, "drive_url")
+        assert hasattr(clip, "download_url")


### PR DESCRIPTION
## 概要
Issue #1 Phase 1: スクレイパー + ダウンローダー実装

## 変更内容

### scraper.py
- `vstudio.team-mir.ai/clips` からの全ページスクレイプ
- BeautifulSoup で `.border.rounded-lg.p-4` カードをパース
- フィールド: `uuid`, `title`, `transcript_text`, `duration_sec`, `video_title`, `drive_file_id`, `download_url`
- `--dry-run`: 1ページのみ取得
- `--max-pages`: ページ数制限

### downloader.py
- Google Drive usercontent 直接DL (`drive.usercontent.google.com/download?id=...&export=download`)
- `posted.db` SQLite tracking: `pending` → `downloaded` → `posted`
- 重複DL防止: `is_downloaded()` チェック
- `--dry-run`: HEAD リクエストで疎通確認のみ

### tests/
- `test_scraper.py`: 21テスト (extract_drive_file_id, parse_duration, parse_clips_from_html)
- `test_downloader.py`: 40テスト (DB操作全ケース, download_clip mocked, process_clips_json)
- ライブテスト: `MIRAI_LIVE_TEST=1` でのみ実行

## テスト結果
```
59 passed, 2 skipped in 2.88s
```

## PRサイズ注記
- ファイル数: 8 / 制限5 → 超過（Phase 1 新規実装のため分割不可）
- 行数: 1053 / 制限200 → 超過（同上）

closes #1